### PR TITLE
Add expression evaluation to data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,6 +511,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "eval"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba90c19bed0c67afb0a24340b42d13ddddcb5413c4c17a04c11871bd6b572c42"
+dependencies = [
+ "quick-error 1.2.3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,7 +713,7 @@ dependencies = [
  "log",
  "pest",
  "pest_derive",
- "quick-error",
+ "quick-error 2.0.0",
  "serde",
  "serde_json",
 ]
@@ -960,6 +971,7 @@ dependencies = [
  "assert_approx_eq",
  "assert_cmd",
  "clap 3.0.0-beta.2",
+ "eval",
  "handlebars",
  "predicates",
  "serde_json",
@@ -1425,6 +1437,12 @@ dependencies = [
  "idna 0.2.3",
  "url 2.2.1",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 tectonic = "0.4.1"
 handlebars = "*"
 serde_json = "*"
+eval = "*"
 
 [dependencies.clap]
 version = "3.0.0-beta.2"

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,7 +137,7 @@ fn parse_cli_args() -> Result<String, String> {
                 Err(e) => return Err(e.to_string()),
             };
 
-            lines = templates::fill_data(&lines, &data);
+            lines = templates::fill_data(&lines, &data)?;
         };
 
         let keep_intermediates = matches.is_present("KEEP_INTERMEDIATES");
@@ -191,7 +191,7 @@ fn parse_cli_args() -> Result<String, String> {
                 Err(e) => return Err(e.to_string()),
             };
 
-            lines = templates::fill_data(&lines, &data);
+            lines = templates::fill_data(&lines, &data)?;
         };
 
         // Return the text to write to stdout.

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -184,14 +184,12 @@ fn pm_helper(
             None => {
                 let e = match attr.relative_path() {
                     Some(rp) => format!("pm got invalid data path: {:?}", rp),
-                    None => {
-                        match attr.value() {
-                            Json::Null => "No argument was found.".to_string(),
-                            v => format!("pm argument: {} is not a valid data path.", v.to_string())
-                        }
-                    }
+                    None => match attr.value() {
+                        Json::Null => "No argument was found.".to_string(),
+                        v => format!("pm argument: {} is not a valid data path.", v.to_string()),
+                    },
                 };
-                return Err(handlebars::RenderError::new::<String>(e))
+                return Err(handlebars::RenderError::new::<String>(e));
             }
         },
         // It only reaches here if no argument was given.

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -610,7 +610,7 @@ fn run_eval(expr_string: &str, data: &Json) -> Result<Json, String> {
         };
 
         // Return an error if the decimal number is not equivalent to an integer.
-        if decimals.round() != decimals {
+        if decimals.fract() > 0.0 {
             return Err(eval::Error::Custom(format!(
                 "Second rounding argument must be an integer. Given value: {}",
                 decimals
@@ -621,7 +621,7 @@ fn run_eval(expr_string: &str, data: &Json) -> Result<Json, String> {
         let rounded = round_value(value, decimals as i32);
 
         // If the value is equivalent of an integer, return an integer form of it.
-        match rounded.round() == rounded {
+        match rounded.fract() == 0.0 {
             true => Ok(serde_json::json!(rounded as i64)),
             false => Ok(serde_json::json!(rounded)),
         }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -106,6 +106,8 @@ fn add_separators(number: f64, separator: &str) -> String {
     // Convert the number into a string.
     let number_str = format!("{}", number);
 
+    let separator_backwards = separator.chars().rev().collect::<String>();
+
     // Convert the real part of the number into a string.
     let real_part_str = format!("{}", number.trunc() as i64);
 
@@ -122,7 +124,7 @@ fn add_separators(number: f64, separator: &str) -> String {
     {
         // If the numbering is divisible by 3, add a separator.
         if (i % 3 == 0) & (i > 0) {
-            new_real_str_rev.push_str(separator);
+            new_real_str_rev.push_str(&separator_backwards);
         };
         // Push the digit as owned.
         new_real_str_rev.push(*c);
@@ -180,10 +182,16 @@ fn pm_helper(
             Some(v) => v,
             // Otherwise, raise an error.
             None => {
-                return Err(handlebars::RenderError::new::<String>(format!(
-                    "pm argument: {} was not a valid data path.",
-                    attr.value().to_string()
-                )))
+                let e = match attr.relative_path() {
+                    Some(rp) => format!("pm got invalid data path: {:?}", rp),
+                    None => {
+                        match attr.value() {
+                            Json::Null => "No argument was found.".to_string(),
+                            v => format!("pm argument: {} is not a valid data path.", v.to_string())
+                        }
+                    }
+                };
+                return Err(handlebars::RenderError::new::<String>(e))
             }
         },
         // It only reaches here if no argument was given.
@@ -598,6 +606,7 @@ mod tests {
 
         assert_eq!(add_separators(10000., ","), "10,000");
         assert_eq!(add_separators(123456.78901, ","), "123,456.78901");
+        assert_eq!(add_separators(123456., "\\,"), "123\\,456");
 
         let data = serde_json::json!({
             "separator": ",",

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -468,7 +468,9 @@ fn round_value(value: f64, decimals: i32) -> f64 {
 }
 
 /// Fill a vector of text with data using templating.
-pub fn fill_data(lines: &[String], data: &serde_json::Value) -> Vec<String> {
+pub fn fill_data(lines: &[String], data: &serde_json::Value) -> Result<Vec<String>, String> {
+    let parsed_data = evaluate_all_expressions(data)?;
+
     let mut new_lines: Vec<String> = Vec::new();
 
     let mut reg = handlebars::Handlebars::new();
@@ -481,7 +483,7 @@ pub fn fill_data(lines: &[String], data: &serde_json::Value) -> Vec<String> {
     reg.set_strict_mode(true);
 
     for (i, line) in lines.iter().enumerate() {
-        match reg.render_template(line, data) {
+        match reg.render_template(line, &parsed_data) {
             Ok(l) => new_lines.push(l),
             Err(e) => {
                 let re = e.as_render_error();
@@ -511,7 +513,220 @@ pub fn fill_data(lines: &[String], data: &serde_json::Value) -> Vec<String> {
         */
     }
 
-    new_lines
+    Ok(new_lines)
+}
+
+/// Recursively find all expressions (strings starting with "expr:") in a json object.
+///
+/// # Arguments
+/// * `data`: The json to find expressions in.
+/// * `parent`: Parent keys to append to the output (only matters internally for recursion)
+///
+/// # Returns
+/// A vector of expressions, where each expression is (vector of keys to find it, expression).
+/// If no expressions are found, this will be empty.
+fn find_expressions(data: &Json, parent: Option<&Vec<String>>) -> Vec<(Vec<String>, String)> {
+    // The parent relative to the current tree is empty if parent was None or the given parent.
+    let relative_parent: Vec<String> = match parent {
+        Some(p) => p.to_owned(),
+        None => Vec::new(),
+    };
+
+    // Create an empty output variable.
+    let mut output: Vec<(Vec<String>, String)> = Vec::new();
+
+    // If the json is an array, parse all expressions in the array.
+    if let Json::Array(arr) = data {
+        // Loop through the array
+        for val in arr {
+            // Recursively find all expressions in the json value.
+            // The parent argument helps retaining the right tree structure.
+            let expressions = find_expressions(val, Some(&relative_parent));
+
+            // Push all found expressions into the output.
+            for expression in expressions {
+                output.push(expression);
+            }
+        }
+    };
+    // If the json is an object (mental note: equivalent to a python dictionary)
+    if let Json::Object(obj) = data {
+        // Loop through all key-value pairs.
+        for (key, val) in obj {
+            // The relative parent of this pair is the upper relative parent plus the key.
+            let mut relative_parent2 = relative_parent.to_owned();
+            relative_parent2.push(key.to_owned());
+
+            // Find all expressions in that value.
+            let expressions = find_expressions(val, Some(&relative_parent2));
+
+            // Push all expressions to the output.
+            for expression in expressions {
+                output.push(expression);
+            }
+        }
+    };
+    // If the json is a string and it countains "expr:", push it to the output.
+    if let Json::String(string) = data {
+        if string.trim().starts_with("expr:") {
+            output.push((relative_parent, string.to_owned()));
+        }
+    };
+    // If the json is any other type of value, it will be skipped.
+
+    output
+}
+
+/// Evaluate a mathematical expression return a useful error if it fails.
+///
+/// It is basically just calling the "eval" crate, but handles error messages better than the
+/// crate does per default.
+///
+/// # Arguments
+/// * `expr_string`: The expression to evaluate.
+/// * `data`: The data "context" to get variables from.
+///
+/// # Returns
+/// The result of the evaluated expression, or an error detailing why it failed.
+fn run_eval(expr_string: &str, data: &Json) -> Result<Json, String> {
+    // Create an expression object from the string.
+    let mut expr = eval::Expr::new(expr_string);
+
+    // Fill the expression with variables from the data.
+    // TODO: Look into if the "json has to be object" check may have side-effects.
+    if let Json::Object(obj) = data {
+        for (key, val) in obj {
+            expr = expr.value(key, val);
+        }
+    };
+
+    // Execute the expression.
+    match expr.exec() {
+        Err(err) => {
+            let mut err_str = err.to_string();
+
+            // If a null was encountered, it is likely that a conexistent key was indexed.
+            if err_str.contains("Null") {
+                err_str += ". Perhaps a key is misspelled?"
+            }
+
+            Err(format!(
+                "Error in expression: '{}': {}",
+                expr_string, err_str
+            ))
+        }
+        Ok(Json::Null) => Err(format!("Expression '{}' returned Null value", expr_string)),
+        Ok(v) => Ok(v),
+    }
+}
+
+/// Evaluate an expression. If needed, recursively evaluate other expressions that it depends on.
+///
+/// # Arguments
+/// * `expression`: The expression to evaluate.
+/// * `data`: The "context" data to parse variables from.
+/// * `recursion_depth`: The current recursion depth (only needed internally).
+fn evaluate_expression(
+    expression: &str,
+    data: &Json,
+    recursion_depth: usize,
+) -> Result<Json, String> {
+    // Avoid circular expressions by setting a max recursion depth.
+    if recursion_depth > 1000 {
+        return Err(format!(
+            "Max recursion depth reached for expression: '{}'. Maybe due to a circular expression?",
+            expression
+        ));
+    };
+
+    // Format the expression string and remove the "expr:" part.
+    let mut expr_string = expression.replacen("expr:", "", 1).trim().to_owned();
+
+    // Find any expressions in the data and check if an associated key is referred to in the
+    // expression.
+    let expressions = find_expressions(data, None);
+    for (keys, expression_str) in &expressions {
+        // If the key exists in the current expression, evaluate the referred expression first.
+        // TODO: Maybe make data mutable so all expressions only have to be evaluated once?
+        if expr_string.contains(&keys.join(".")) {
+            // Evaluate the referred expression.
+            let value = evaluate_expression(&expression_str, &data, recursion_depth + 1)?;
+            // Replace its key in the current expression with the evaluated value.
+            expr_string = expr_string.replace(&keys.join("."), &value.to_string());
+        }
+    }
+
+    // Now that all potential referred expressions have been evaluated, evaluate the current one.
+    run_eval(&expr_string, &data)
+}
+
+/// Set data in a json at an arbitrary tree depth.
+///
+/// It does not set new keys, it only replaces the content of an existing key.
+///
+/// # Arguments
+/// * `data`: The json to set a value in.
+/// * `keys`: A vector of keys to index `data` with.
+/// * `value`: The new value to set
+///
+/// # Returns
+/// Nothing if it worked, or an error saying "Key not found" if the key did not exist.
+fn replace_value_in_data(data: &mut Json, keys: &[String], value: Json) -> Result<(), String> {
+    // If the keys is not just a single key, recursively dive into the tree.
+    if keys.len() > 1 {
+        // Extract the first key.
+        let first_key = &keys[0];
+
+        // Try to get the value of the first key.
+        let mut subset = match data.get_mut(first_key) {
+            Some(s) => s,
+            None => return Err("Key not found".into()),
+        };
+        // Run the function again on the next keys.
+        replace_value_in_data(&mut subset, &keys[1..], value)?;
+    } else {
+        // If the keys is a single key (it will be reached using recursion if not)...
+        // ... try to set the value.
+
+        match data.get_mut(&keys[0]) {
+            Some(v) => (*v = value),
+            None => return Err("Key not found".into()),
+        };
+    };
+
+    Ok(())
+}
+
+/// Try to evaluate all expressions in a data file.
+///
+/// # Arguments
+/// `data`: The data file to evaluate expressions inside.
+///
+/// # Returns
+/// A copy of the data file with expressions filled, or an error detailing why it failed.
+fn evaluate_all_expressions(data: &Json) -> Result<Json, String> {
+    let mut new_data = data.clone();
+
+    // Find all expressions and evaluate them (recursively if needed)
+    for (keys, expr_string) in find_expressions(data, None) {
+        let new_value = match evaluate_expression(&expr_string, &new_data, 0) {
+            Ok(v) => v,
+            Err(e) => {
+                return Err(format!(
+                    "Error for expression in '{}' ('{}'): {:?}",
+                    keys.join("."),
+                    expr_string,
+                    e
+                ))
+            }
+        };
+        // Replace the expression with the evaluated value.
+        match replace_value_in_data(&mut new_data, &keys, new_value) {
+            Ok(_) => (),
+            Err(e) => return Err(format!("Error setting key '{}': {}", keys.join("."), e)),
+        };
+    }
+    Ok(new_data)
 }
 
 #[cfg(test)]
@@ -530,7 +745,7 @@ mod tests {
 
         let data = serde_json::json!({"years": 24});
 
-        let new_lines = fill_data(&lines, &data);
+        let new_lines = fill_data(&lines, &data).unwrap();
 
         assert_eq!(new_lines[1], "I am 24 years old.");
     }
@@ -549,7 +764,7 @@ mod tests {
             "This package is called {{package_name}}.".into(),
         ];
 
-        let new_lines = fill_data(&lines, &data);
+        let new_lines = fill_data(&lines, &data).unwrap();
 
         assert_eq!(new_lines[0], "The year was once 2000");
         assert_eq!(new_lines[1], "This package is called manus.")
@@ -566,7 +781,7 @@ mod tests {
         // Try the large value as an integer and decimal_value as a string.
         let data = serde_json::json!({"large_value": 8699, "decimal_value": "1.234"});
 
-        let new_lines = fill_data(&lines, &data);
+        let new_lines = fill_data(&lines, &data).unwrap();
 
         assert_eq!(round_value(1.234, 1), 1.2);
         assert_eq!(round_value(8699_f64, -3), 9000.0);
@@ -586,7 +801,7 @@ mod tests {
 
         let data = serde_json::json!({"data": {"value": 1.2345, "value_pm": 0.2345}, "value2": 2, "value2_pm": 0.1});
 
-        let new_lines = fill_data(&lines, &data);
+        let new_lines = fill_data(&lines, &data).unwrap();
 
         assert_eq!(new_lines[0], "The value is 1.2345$\\pm$0.2345");
         assert_eq!(new_lines[1], "The value is 1.2$\\pm$0.2");
@@ -613,7 +828,7 @@ mod tests {
             "value_pm": 12456
         });
 
-        let new_lines = fill_data(&lines, &data);
+        let new_lines = fill_data(&lines, &data).unwrap();
 
         assert_eq!(new_lines[0], "10000 is a large number.");
         assert_eq!(new_lines[1], "10,000 looks better.");
@@ -622,5 +837,57 @@ mod tests {
             "Data are 12,345 years old with a mean of 1.4858"
         );
         assert_eq!(new_lines[3], "-123,456,789$\\pm$12,456");
+    }
+
+    #[test]
+    fn test_expressions() {
+        let lines: Vec<String> = vec![
+            "The percentage of {{small}} out of {{large}} is {{round percentage}}".into(),
+            "Adding one percentage point, it becomes: {{round added_percentage}}".into(),
+        ];
+
+        let data = serde_json::json!({
+            "large": 10000,
+            "small": 200,
+            "percentage": "expr: 100 * small / large",
+            "added_percentage": "expr: percentage + 1",
+            "three": "expr: 1 + 2",
+            "nested_expressions": {
+                "value_sum": "expr: large + small",
+            }
+        });
+
+        assert_eq!(run_eval(&"100 * 3", &data), Ok(serde_json::json!(300)));
+
+        // This will fail because of a misspelled key.
+        if let Err(e) = run_eval(&"largee + small", &data) {
+            assert!(e.contains("Perhaps a key is misspelled?"));
+        }
+
+        println!("{:?}", find_expressions(&data, None));
+
+        let parsed_data = evaluate_all_expressions(&data).unwrap();
+
+        let new_lines = fill_data(&lines, &parsed_data).unwrap();
+
+        assert_eq!(parsed_data["three"], serde_json::json!(3));
+        assert_eq!(parsed_data["percentage"], serde_json::json!(2.0));
+
+        assert_eq!(new_lines[0], "The percentage of 200 out of 10000 is 2");
+        assert_eq!(new_lines[1], "Adding one percentage point, it becomes: 3");
+
+        // Make some expressions with circular dependencies (should raise a recursion error).
+        let data = serde_json::json!({
+            "ex1": "expr: ex2 + 1",
+            "ex2": "expr: ex1 + 1",
+            "ex3": "expr: ex3 + 1"
+        });
+
+        assert!(data.is_object());
+
+        match evaluate_expression("ex1 + ex2", &data, 0) {
+            Ok(v) => panic!("This should have failed!: {:?}", v),
+            Err(s) => assert!(s.contains("recursion"), "{}", s),
+        };
     }
 }

--- a/tests/data/case3/data.json
+++ b/tests/data/case3/data.json
@@ -1,10 +1,14 @@
 {
+	"separator": "\\,",
 	"units": {
 		"change": "m",
-		"volume_change": "m a"
+		"volume_change": "m$^3$"
 	},
 	"results": {
 		"change": 1.2805909,
-		"change_pm": 0.49567
+		"area": 10000,
+		"change_pm": 0.49567,
+		"change_vol": "expr: results.change * results.area",
+		"change_vol_pm": "expr: results.change_pm * results.area"
 	}
 }

--- a/tests/data/case3/main.tex
+++ b/tests/data/case3/main.tex
@@ -7,6 +7,7 @@
 
 ArcticDEMs are made by \citet{porter_arcticdem_2018}.
 They showed a mean change of {{pm 1 results.change}} {{units.change}}.
+This equates to a volume change of {{sep (pm 1 results.change_vol)}} {{units.volume_change}}.
 
 
 \bibliography{library.bib}


### PR DESCRIPTION
Expressions can now be made inside the data file:
```json
{
    "first_number": 5,
    "second_number": 9,
    "number_sum": "expr: first_number + second_number"
}
```
where the tex code:
```latex
{{first_number}} plus {{second_number}} is {{number_sum}}
```
would print:
```
5 plus 9 is 14
```

This is useful for many purposes, e.g. for volume change calculations or percentages:
```json
{
    "change_meters": 10,
    "area_m2": 1000,
    "change_volume": "expr: change_meters * area",
    "total_volume": 20000,
    "change_percentage": "expr: round(100 * change_volume / total_volume)"
}
```
where `{{change_percentage}}` would be `50`.