### PR TITLE
Add TOML data file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "serde_json",
  "tectonic",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 tectonic = "0.4.1"
 handlebars = "*"
 serde_json = "*"
+toml = "*"
 
 [dependencies.clap]
 version = "3.0.0-beta.2"

--- a/src/io.rs
+++ b/src/io.rs
@@ -159,10 +159,22 @@ pub fn read_tex_from_stdin() -> Result<Vec<String>, Box<dyn std::error::Error>> 
 /// Read a json data file into an arbitrary JSON dictionary.
 pub fn read_data(filepath: &Path) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
     let file = File::open(filepath)?;
-    let reader = std::io::BufReader::new(file);
+    let mut reader = std::io::BufReader::new(file);
 
-    let data: serde_json::Value = serde_json::from_reader(reader)?;
+    let mut buf = String::new();
+    reader.read_to_string(&mut buf)?;
 
+    let extension = filepath
+        .extension()
+        .expect("Data file read with no extension!")
+        .to_str()
+        .unwrap();
+
+    let data: Json = match extension {
+        "json" => serde_json::from_str(&buf)?,
+        "toml" => toml::from_str(&buf)?,
+        s => return Err(format!("Could not read data type: {}", s).into()),
+    };
     Ok(data)
 }
 

--- a/tests/data/case4/data.toml
+++ b/tests/data/case4/data.toml
@@ -1,0 +1,5 @@
+number = 0.4
+
+[data]
+number1 = 1  # This is a comment.
+number2 = 2

--- a/tests/data/case4/main.tex
+++ b/tests/data/case4/main.tex
@@ -1,0 +1,9 @@
+\documentclass{article}
+
+\begin{document}
+
+Number zero point four is {{number}} in numeric.
+
+The first numbers from one are: {{data.number1}} and {{data.number2}}.
+
+\end{document}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -135,4 +135,25 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_toml_data() -> Result<(), Box<dyn std::error::Error>> {
+        let mut cmd = Command::cargo_bin("manus")?;
+
+        cmd.arg("convert")
+            .arg("--data=tests/data/case4/data.toml")
+            .arg("--format=tex")
+            .arg("tests/data/case4/main.tex");
+
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains(
+                "Number zero point four is 0.4 in numeric",
+            ))
+            .stdout(predicate::str::contains(
+                "The first numbers from one are: 1 and 2.",
+            ));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
TOML files are slightly nicer than JSON because they are easier to read, and allow comments:

```json
{
    "hello": "there",
    "data": {
          "number1": 1,
          "number2": 2
    }
}
```
is equivalent to:
```toml
hello = "there"  # This is a comment

[data]
number1 = 1
number2 = 2  # It is more readable and allows commenting to make things easier.
```
This should be appealing to a larger audience. For now, however, only JSON is supported through piping.

Solves #4.